### PR TITLE
Topic/detect frame with browsing context name

### DIFF
--- a/relay/rp/index.html
+++ b/relay/rp/index.html
@@ -39,7 +39,7 @@
       <script>
         (function () {
           var start_dancing = function (clicked) {
-            window.open(clicked.srcElement.href, '_unauthenticated', 'width=500, height=400');
+            window.open(clicked.target.href, '_unauthenticated', 'width=500, height=400');
 
             window.addEventListener('message', function (event) {
               if (event.origin != 'http://relay-as.dev') return;

--- a/relay/rp/index.html
+++ b/relay/rp/index.html
@@ -9,12 +9,12 @@
 
     <article>
       <h2>Message Target Window</h2>
-      <iframe id="message-target" src="http://relay-rs.dev/message-target.html" width="450" height="170"></iframe>
+      <iframe id="message-target" name="message-target" src="http://relay-rs.dev/message-target.html" width="450" height="170"></iframe>
     </article>
 
     <article>
       <h2>Using Authenticated iframe Window</h2>
-      <iframe src="http://relay-as.dev/authenticated.html?client_id=abc&state=state-authenticated&resonse_type=token&response_mode=web_message&redirect_uri=http://relay-rp.dev&web_message_uri=http://relay-rs.dev&web_message_target=0" width="450" height="80"></iframe>
+      <iframe src="http://relay-as.dev/authenticated.html?client_id=abc&state=state-authenticated&resonse_type=token&response_mode=web_message&redirect_uri=http://relay-rp.dev&web_message_uri=http://relay-rs.dev&web_message_target=message-target" width="450" height="80"></iframe>
       <script>
         (function () {
           window.addEventListener('message', function (event) {
@@ -33,7 +33,7 @@
 
     <article>
       <h2>Using Unauthenticated Popup Window</h2>
-      <a id="unauthenticated-link" href="http://relay-as.dev/unauthenticated.html?client_id=abc&state=state-unauthenticated&resonse_type=token&response_mode=web_message&redirect_uri=http://relay-rp.dev&web_message_uri=http://relay-rs.dev&web_message_target=0">
+      <a id="unauthenticated-link" href="http://relay-as.dev/unauthenticated.html?client_id=abc&state=state-unauthenticated&resonse_type=token&response_mode=web_message&redirect_uri=http://relay-rp.dev&web_message_uri=http://relay-rs.dev&web_message_target=message-target">
         Open Unauthenticated Popup Window
       </a>
       <script>

--- a/relay/rs/message-target.html
+++ b/relay/rs/message-target.html
@@ -14,7 +14,7 @@
 
           if (event.data && event.data.type == 'authorization_response') {
             console.info('In Message Target Window', event.data);
-            document.getElementById('display').innerText = JSON.stringify(event.data.response, null, 2);
+            document.getElementById('display').textContent = JSON.stringify(event.data.response, null, 2);
           }
 
           if (event.source.parent == event.source) {

--- a/simple/rp/index.html
+++ b/simple/rp/index.html
@@ -19,7 +19,7 @@
 
             if (event.data.type == 'authorization_response') {
               console.info('From Authenticated Window', event.data);
-              document.getElementById('display').innerText = JSON.stringify(event.data.response, null, 2);
+              document.getElementById('display').textContent = JSON.stringify(event.data.response, null, 2);
               window.removeEventListener('message', arguments.callee);
             }
           });
@@ -35,14 +35,14 @@
       <script>
         (function () {
           var start_dancing = function (clicked) {
-            window.open(clicked.srcElement.href, '_unauthenticated', 'width=500, height=400');
+            window.open(clicked.target.href, '_unauthenticated', 'width=500, height=400');
 
             window.addEventListener('message', function (event) {
               if (event.origin != 'http://simple-as.dev') return;
 
               if (event.data.type == 'authorization_response') {
                 console.info('From Unauthenticated Window', event.data);
-                document.getElementById('display').innerText = JSON.stringify(event.data.response, null, 2);
+                document.getElementById('display').textContent = JSON.stringify(event.data.response, null, 2);
                 window.removeEventListener('message', arguments.callee);
                 event.source.close();
               }


### PR DESCRIPTION
@nov @zigorou 

田中です。権限頂いてから時間空いてしまい恐縮です。

配列の添字でなければ cross origin の window を取得できなかった件について、iframe 生成時の指定方法が違っていたようなので修正を送ります。

また、firefox で動作しなかった部分 ( srcElement, innerText ) も併せて変えております。PR 分けるべきであればご指摘ください。
##### 補足
- `window.frames[ targetName ] (または window[ targetName ])` としてネストされた window オブジェクトを取得する場合、対象の browsing context 名を指定する必要があり、この時 `<iframe>` 要素に紐付く browsing context の名称は name 属性で決定するようです。
  - http://www.w3.org/TR/html5/browsers.html#named-access-on-the-window-object
  - http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-name
- Chrome (46.0), Firefox (41.0) で確認したところ `<iframe>` に id のみを指定した場合に `window[ targetId ]` で取得できるものは HTMLElement となる (`<a>` など他の要素に id 指定した場合と同じ) ので、これまで出ていた `Uncaught DOMException: Blocked a frame with origin "http://relay-as.dev" from accessing a cross-origin frame.` のようなエラーは event source の DOM 要素にアクセスしようとしたために怒られていたものだと思います。
  - IE11 の場合は id のみを指定しても window オブジェクトが返ってきました 
